### PR TITLE
fix HTTPREquestParser

### DIFF
--- a/incs/http/parser/HttpRequestParser.hpp
+++ b/incs/http/parser/HttpRequestParser.hpp
@@ -25,12 +25,12 @@ private:
 
 public:
     HttpRequestParser(HttpRequest *httpRequest);
-    void parseRequest(std::vector<char> &buffer);
+    const RequestParseState &parseRequest(std::vector<char> &buffer);
     void clearBuffer();
-    RequestParseState getState();
-    int getReadBodySize();
-    HttpRequest *getHttpRequest();
-    std::vector<char> getBuffer();
+    const RequestParseState &getState();
+    const int & getReadBodySize();
+    const HttpRequest &getHttpRequest();
+    const std::vector<char> & getBuffer();
 
 private:
     void handleStartLineState(std::vector<char> &buffer);

--- a/srcs/http/parser/HttpRequestParser.cpp
+++ b/srcs/http/parser/HttpRequestParser.cpp
@@ -6,7 +6,7 @@ HttpRequestParser::HttpRequestParser(HttpRequest *httpRequest)
 {
 }
 
-void HttpRequestParser::parseRequest(std::vector<char> &buffer) {
+const RequestParseState &HttpRequestParser::parseRequest(std::vector<char> &buffer) {
     if (!this->_buffer.empty()){
         buffer.insert(buffer.begin(), this->_buffer.begin(), this->_buffer.end());
         this->_buffer.clear();
@@ -17,6 +17,7 @@ void HttpRequestParser::parseRequest(std::vector<char> &buffer) {
         handleHeaderState(buffer);
     if (_state == BODY)
         handleBodyState(buffer);
+    return this->_state;
 }
 
 void HttpRequestParser::handleStartLineState(std::vector<char> &buffer) {
@@ -67,18 +68,18 @@ void HttpRequestParser::handleBodyState(std::vector<char> &buffer) {
     _readBodySize += buffer.size();
 }
 
-RequestParseState HttpRequestParser::getState() {
+const RequestParseState &HttpRequestParser::getState() {
     return this->_state;
 }
 
-int HttpRequestParser::getReadBodySize() {
+const int &HttpRequestParser::getReadBodySize() {
     return this->_readBodySize;
 }
 
-HttpRequest *HttpRequestParser::getHttpRequest() {
-    return this->_httpRequest;
+const HttpRequest &HttpRequestParser::getHttpRequest() {
+    return *(this->_httpRequest);
 }
 
-std::vector<char> HttpRequestParser::getBuffer() {
+const std::vector<char> &HttpRequestParser::getBuffer() {
     return this->_buffer;
 }


### PR DESCRIPTION
 ## 📌 매서드 반환타입 const수정 및  파서가 스테이트반환하도록 수정
  -
 ## 💻 매서드들 반환타입 기본 방식수정 
  -
 ## ✅ 파서가 스테이트를 반환해서 나머지 다른 일을 하는 친구와 상호작용하도록 수정 (다른 클래스가 파서에 의존성이 걸릴 수 있는 문제 생각해볼 필요 있음)
  -
